### PR TITLE
Fix firefox profiler imports

### DIFF
--- a/crates/tracing-trace/src/processor/firefox_profiler.rs
+++ b/crates/tracing-trace/src/processor/firefox_profiler.rs
@@ -1,10 +1,12 @@
 use std::collections::HashMap;
 
 use fxprof_processed_profile::{
+    markers::{
+        MarkerDynamicField, MarkerFieldFormat, MarkerLocation, MarkerSchema,
+        MarkerSchemaField, ProfilerMarker,
+    },
     CategoryHandle, CategoryPairHandle, CounterHandle, CpuDelta, Frame, FrameFlags, FrameInfo,
-    MarkerDynamicField, MarkerFieldFormat, MarkerLocation, MarkerSchema, MarkerSchemaField,
-    ProcessHandle, Profile, ProfilerMarker, ReferenceTimestamp, SamplingInterval, StringHandle,
-    Timestamp,
+    ProcessHandle, Profile, ReferenceTimestamp, SamplingInterval, StringHandle, Timestamp,
 };
 use serde_json::json;
 


### PR DESCRIPTION
## Summary
- fix `fxprof_processed_profile` imports in firefox profiler

## Testing
- `cargo build --release` *(fails: Tool not installed for shim: cargo)*

------
https://chatgpt.com/codex/tasks/task_e_6880996febd88323b4994b7333f2564f