### PR TITLE
Fix imports for updated fxprof crate

### DIFF
--- a/crates/tracing-trace/src/processor/firefox_profiler.rs
+++ b/crates/tracing-trace/src/processor/firefox_profiler.rs
@@ -1,12 +1,9 @@
 use std::collections::HashMap;
 
 use fxprof_processed_profile::{
-    markers::{
-        MarkerDynamicField, MarkerFieldFormat, MarkerLocation, MarkerSchema,
-        MarkerSchemaField, ProfilerMarker,
-    },
-    CategoryHandle, CategoryPairHandle, CounterHandle, CpuDelta, Frame, FrameFlags, FrameInfo,
-    ProcessHandle, Profile, ReferenceTimestamp, SamplingInterval, StringHandle, Timestamp,
+    MarkerDynamicField, MarkerFieldFormat, MarkerLocation, MarkerSchema, MarkerSchemaField,
+    ProfilerMarker, CategoryHandle, CategoryPairHandle, CounterHandle, CpuDelta, Frame, FrameFlags,
+    FrameInfo, ProcessHandle, Profile, ReferenceTimestamp, SamplingInterval, StringHandle, Timestamp,
 };
 use serde_json::json;
 


### PR DESCRIPTION
## Summary
- fix import paths in `firefox_profiler.rs`

## Testing
- `cargo check -p tracing-trace` *(fails: unable to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68809fb5ba508323a9c610c44de4527e