### PR TITLE
Fix firefox profiler imports

### DIFF
--- a/crates/tracing-trace/src/processor/firefox_profiler.rs
+++ b/crates/tracing-trace/src/processor/firefox_profiler.rs
@@ -1,8 +1,11 @@
 use std::collections::HashMap;
 
 use fxprof_processed_profile::{
-    MarkerDynamicField, MarkerFieldFormat, MarkerLocation, MarkerSchema, MarkerSchemaField,
-    ProfilerMarker, CategoryHandle, CategoryPairHandle, CounterHandle, CpuDelta, Frame, FrameFlags,
+    markers::{
+        MarkerDynamicField, MarkerFieldFormat, MarkerLocation, MarkerSchema, MarkerSchemaField,
+        ProfilerMarker,
+    },
+    CategoryHandle, CategoryPairHandle, CounterHandle, CpuDelta, Frame, FrameFlags,
     FrameInfo, ProcessHandle, Profile, ReferenceTimestamp, SamplingInterval, StringHandle, Timestamp,
 };
 use serde_json::json;


### PR DESCRIPTION
## Summary
- fix import paths for `fxprof_processed_profile` markers

## Testing
- `mise install rust` *(fails: could not download toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_6880a50496808323a753351f75b3e154