### PR TITLE
Fix firefox profiler import

### DIFF
--- a/crates/tracing-trace/src/processor/firefox_profiler.rs
+++ b/crates/tracing-trace/src/processor/firefox_profiler.rs
@@ -1,11 +1,8 @@
 use std::collections::HashMap;
 
 use fxprof_processed_profile::{
-    markers::{
-        MarkerDynamicField, MarkerFieldFormat, MarkerLocation, MarkerSchema, MarkerSchemaField,
-        ProfilerMarker,
-    },
-    CategoryHandle, CategoryPairHandle, CounterHandle, CpuDelta, Frame, FrameFlags,
+    MarkerDynamicField, MarkerFieldFormat, MarkerLocation, MarkerSchema, MarkerSchemaField,
+    ProfilerMarker, CategoryHandle, CategoryPairHandle, CounterHandle, CpuDelta, Frame, FrameFlags,
     FrameInfo, ProcessHandle, Profile, ReferenceTimestamp, SamplingInterval, StringHandle, Timestamp,
 };
 use serde_json::json;


### PR DESCRIPTION
## Summary
- fix import paths for firefox profiler markers so build succeeds with fxprof-processed-profile 0.8.1

## Testing
- `cargo build --offline -p tracing-trace` *(fails: Tool not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6880a866b6988323bede89584f7f3e4a